### PR TITLE
支持企业微信原生webhook机器人

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 hwamei 是一个基于 hubot 的企业微信聊天机器人，它能够通过 webhook 将收集的信息发送到企业微信群中。
 
+已兼容企业微信原生webhook机器人！！！ 具体见 https://github.com/tlikai/hwamei/pull/2
+
 ## 预览
 
 ![企业微信群聊天机器人](http://p.qpic.cn/pic_wework/439528718/dadcc3d69e2a69710cbb7ce270aab93f77fa86e5d64bf11c/0)

--- a/lib/webhook_handlers.js
+++ b/lib/webhook_handlers.js
@@ -1,34 +1,28 @@
 module.exports = {
-  incoming: function (webhook, params) {
-    let lines = [];
+  incoming: function (params) {
     if (params.payload) {
       params = JSON.parse(params.payload)
     }
 
-    let text = params.text || params.message
-    let datetime = currentDateTime()
-    lines.push(`【${webhook.name} - ${datetime}】${text}`)
+    let content = params.text || params.message
+    let datetime = formattedDateTime()
+    let message = `【${datetime}】${content}`
 
-    return {
-      'content': lines.join("\n"),
-    }
+    return message
   },
-  sentry: function (webhook, params) {
-    let lines = [];
+  sentry: function (params) {
+    let lines = []
+    let datetime = formattedDateTime()
+    lines.push(`【${datetime}】${params.message}\n`)
     lines.push(`【错误级别】${params.level}`)
-    lines.push(`【罪魁祸首】${params.culprit}`)
-
+    lines.push(`【错误原因】${params.culprit}`)
     if (params.extra && params.extra.url) {
-      lines.push(`【相关链接】${params.extra.url}`)
+      lines.push(`【错误链接】${params.extra.url}`)
     }
 
-    return {
-      'url': params.url,
-      'title': `【${webhook.name}】${params.message}`,
-      'content': renderContent(lines.join("\n"))
-    }
+    return lines.join("\n")
   },
-  gitlab: function(webhook, params) {
+  gitlab: function(params) {
     let url = ''
     let title = ''
     let lines = []
@@ -56,13 +50,9 @@ module.exports = {
       console.log(JSON.stringify(params))
     }
 
-    return {
-      'url': url,
-      'title': title,
-      'content': renderContent(lines.join("\n"))
-    }
+    return lines.join("\n")
   },
-  github: function(webhook, params) {
+  github: function(params) {
     let url = ''
     let title = ''
     let lines = []
@@ -80,22 +70,14 @@ module.exports = {
       url = 'https://gitlab.com'
       title = `【Github】不支持的事件类型`
       lines.push(`如果需要，自己实现一下吧！`)
-      console.log(JSON.stringify(params))
+      lines.push(JSON.stringify(params))
     }
 
-    return {
-      'url': url,
-      'title': title,
-      'content': renderContent(lines.join("\n"))
-    }
+    return lines.join("\n")
   }
 }
 
-function renderContent(content) {
-  return content.replace(/【(.*)】/ig, '<div class="highlight">【$1】</div>')
-}
-
-function currentDateTime() {
+function formattedDateTime() {
   let date = new Date()
   let month = date.getMonth() + 1
   let hour = date.getHours()

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
@@ -69,12 +69,12 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/aws-sign2/download/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
@@ -83,12 +83,12 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
         "follow-redirects": "1.5.10",
-        "is-buffer": "1.1.6"
+        "is-buffer": "2.0.3"
       }
     },
     "base64-url": {
@@ -185,7 +185,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
@@ -410,7 +410,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "1.0.0"
@@ -426,7 +426,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
@@ -582,7 +582,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
@@ -592,7 +592,7 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/fast-json-stable-stringify/download/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "finalhandler": {
@@ -639,14 +639,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/forever-agent/download/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
@@ -686,7 +686,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
@@ -694,7 +694,7 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/har-schema/download/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
@@ -725,7 +725,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -778,13 +778,13 @@
       "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
@@ -794,17 +794,17 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -814,12 +814,12 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/jsprim/download/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -1004,7 +1004,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/performance-now/download/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "proxy-addr": {
@@ -1402,7 +1402,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "5.1.2"
@@ -1410,7 +1410,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "http://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-is": {
@@ -1460,7 +1460,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -1479,6 +1479,22 @@
       "integrity": "sha512-cmp0ynP29ufQT7LemKmTwmzgEha/5qTl7W3EeS8c5bGtt8iRxLHmOV6pBdkIL2a/xVLl0D98Cc8ARf5p4Ihnbw==",
       "requires": {
         "axios": "0.18.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "1.1.6"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "likai <youyuge@gmail.com>",
   "description": "A simple helpful robot for your Company",
   "dependencies": {
+    "axios": "^0.19.0",
     "cron": "latest",
     "dotenv": "latest",
     "hubot": "^2.19.0",

--- a/scripts/http.js
+++ b/scripts/http.js
@@ -1,0 +1,79 @@
+// Description:
+//   http server
+//
+// Dependencies:
+//   "hubot-redis-brain": "0.0.4"
+//
+// Configuration:
+//   none
+//
+// Commands:
+//   none
+
+const wxwork = require('../lib/wxwork')
+const handlers = require('../lib/webhook_handlers')
+const axios = require('axios')
+
+module.exports = (robot) => {
+  robot.router.post('/:type/:token', (req, res) => {
+    const type = req.params.type
+    const token = req.params.token
+    const webhooks = robot.brain.get('webhooks', {})
+
+    if (!webhooks[token]) {
+      return res.send("Invalid token")
+    }
+
+    webhook = webhooks[token]
+    const chatId = webhook['chat_id']
+    const message = resolveMessageObject(type, req.body)
+
+    if (message === false) {
+      res.send('Invalid handler')
+    }
+
+    async function sendMessage(chatId, message){
+      let response = await wxwork.sendMessage(chatId, message)
+      if (response.ok) {
+        res.send(message)
+      } else {
+        res.send(response.message)
+      }
+    }
+
+    sendMessage(chatId, message)
+  })
+
+  robot.router.post('/wxwork_webhook/:type/:token', (req, res) => {
+    const type = req.params.type
+    const token = req.params.token
+    const message = resolveMessageObject(type, req.body)
+
+    let data = {
+      msgtype: 'text',
+      text: {
+        content: message
+      }
+    }
+
+    const url = `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${token}`
+    axios.post(url, data).then((resp) => {
+      if (resp.data.errmsg != 'ok') {
+        console.log(resp.data.errmsg)
+      } else {
+        console.log(message)
+      }
+    }).catch((error) => {
+      console.log(error)
+    })
+  })
+}
+
+function resolveMessageObject(name, params) {
+  try {
+    return handlers[name](params)
+  } catch (error) {
+    console.error(error)
+    return false
+  }
+}

--- a/scripts/webhook.js
+++ b/scripts/webhook.js
@@ -17,8 +17,6 @@
 //   load webhooks
 
 const fs = require('fs')
-const wxwork = require('../lib/wxwork')
-const handlers = require('../lib/webhook_handlers')
 
 module.exports = (robot) => {
   robot.hear(/webhook create (.*) from (.*) to (.*)/, (res) => {
@@ -103,60 +101,4 @@ module.exports = (robot) => {
 
     res.send('Done')
   })
-
-  robot.router.post('/:type/:token', (req, res) => {
-    const type = req.params.type
-    const token = req.params.token
-    const webhooks = robot.brain.get('webhooks', {})
-
-    if (!webhooks[token]) {
-      return res.send("Invalid token")
-    }
-
-    webhook = webhooks[token]
-    const chatId = webhook['chat_id']
-    const messageObject = resolveMessageObject(type, webhook, req.body)
-
-    if (messageObject === false) {
-      res.send('Invalid handler')
-    }
-
-    async function sendMessage(chatId, messageObject){
-      let response
-      if (messageObject.title) {
-        response = await wxwork.sendCard(chatId,
-          messageObject.title, messageObject.content, messageObject.url)
-      } else {
-        response = await wxwork.sendMessage(chatId,
-          messageObject.content)
-      }
-
-      if (response.ok) {
-        res.send('OK')
-      } else {
-        res.send(response.message)
-      }
-    }
-
-    sendMessage(chatId, messageObject)
-  })
-}
-
-function resolveMessageObject(name, webhook, params) {
-  try {
-    return handlers[name](webhook, params)
-  } catch (error) {
-    console.error(error)
-    return false
-  }
-}
-
-function generateUUID(){
-    var d = new Date().getTime()
-    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-        var r = (d + Math.random()*16)%16 | 0
-        d = Math.floor(d/16)
-        return (c=='x' ? r : (r&0x7|0x8)).toString(16)
-    });
-    return uuid
 }


### PR DESCRIPTION
企业微信原生的webhook很好，用起来很方便，唯一问题是参数格式太变态了，所以有了下面这个兼容方案。

假设你新建了一个原生企业微信webhook机器人，对应的URL如下：
`https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=a539a69b-c55b-4263-9dc5-21998b17ad60`

你只需要将该URL修改为hwamei的转接URL，即可保持hwamei原有的webhook输入格式不变，且直接使用企业微信原生webhook机器人，转换URL如下：
`http://yourhost/wxwork_webhook/incoming/a539a69b-c55b-4263-9dc5-21998b17ad60`